### PR TITLE
IPMIv2.0/RMCP+

### DIFF
--- a/src/eipmi.erl
+++ b/src/eipmi.erl
@@ -126,15 +126,21 @@
         clock_wakeup.
 
 -type option_name() ::
-        initial_outbound_seq_nr | keep_alive_retransmits | password | port |
-        privilege | rq_addr | timeout | user.
+        encrypt_type | initial_outbound_seq_nr | integrity_type |
+        keep_alive_retransmits | lookup_type | password | port | privilege |
+        rakp_auth_type | rq_addr | timeout | user.
 -type option() ::
+        {encrypt_type, eipmi_auth:encrypt_type()} |
         {initial_outbound_seq_nr, non_neg_integer()} |
+        {integrity_type, eipmi_auth:integrity_type()} |
         {keep_alive_retransmits, non_neg_integer()} |
+        {lookup_type, 0..1} |
         {password, string()} |
         {port, inet:port_number()} |
         {privilege, privilege()} |
+        {rakp_auth_type, eipmi_auth:rakp_type()} |
         {rq_addr, 16#81..16#8d} |
+        {rq_auth_type, eimpi_auth:type() | rmcp_plus} |
         {timeout, non_neg_integer()} |
         {user, string()}.
 
@@ -451,20 +457,35 @@ open(Host) ->
 %% Same as {@link open/1} but allows the specification of the following custom
 %% options:
 %% <dl>
+%%   <dt>`{encrypt_type, eipmi_auth:encrypt_type()}'</dt>
+%%   <dd>
+%%     <p>
+%%     The Confidentiality algorithm used to encrypt RMCP+ sessions, default
+%%     is `none'.
+%%     </p>
+%%   </dd>
 %%   <dt>`{initial_outbound_seq_nr, non_neg_integer()}'</dt>
 %%   <dd>
 %%     <p>
-%%     The initial outbound sequence number that will be requested on the BMC,
+%%     The initial outbound sequence number that will be requested on the
+%%     BMC,
 %%     default is `16#1337'.
 %%     </p>
-%%  </dd>
+%%   </dd>
+%%   <dt>`{integrity_type, eipmi_auth:integrity_type()}'</dt>
+%%   <dd>
+%%     <p>
+%%     The Integrity algorithm used to sign RMCP+ session messages, default
+%%     is `none'.
+%%     </p>
+%%   </dd>
 %%   <dt>`{keep_alive_retransmits, non_neg_integer()}'</dt>
 %%   <dd>
 %%     <p>
 %%     The number of retransmits allowed for session keep_alive requests,
 %%     default is `2'.
 %%     </p>
-%%  </dd>
+%%   </dd>
 %%   <dt>`{password, string() with length <= 16bytes}'</dt>
 %%   <dd>
 %%     <p>
@@ -486,11 +507,35 @@ open(Host) ->
 %%     `administrator'.
 %%     </p>
 %%   </dd>
+%%   <dt>`{rakp_auth_type, eipmi_auth:rakp_type()}'</dt>
+%%   <dd>
+%%     <p>
+%%     The RMCP+ Authenticated Key-Exchange Protocol used to activate a
+%%     session, referring to the HMAC algorithm used to authenticate the key
+%%     exchange. Default is `none', meaning RAKP happens, but no messages are
+%%     signed.
+%%     </p>
+%%   </dd>
 %%   <dt>`{rq_addr, 16#81..16#8d}'</dt>
 %%   <dd>
 %%     <p>
 %%     The requestor address used in IPMI lan packages, the default value of
 %%     `16#81' should be suitable for all common cases.
+%%     </p>
+%%   </dd>
+%%   <dt>`{rq_auth_type, none | pwd | md5 | md2}'</dt>
+%%   <dd>
+%%     <p>
+%%     The requested authentication algorithm used to sign IPMI v1.5 messages
+%%     in active sessions. If the device does not support the requested
+%%     algorithm, another will be used.
+%%     </p>
+%%   </dd>
+%%   <dt>`{rq_session_id, non_neg_integer()}'</dt>
+%%   <dd>
+%%     <p>
+%%     The requested session ID the device should use when sending responses
+%%     during RAKP, default is 16#1337c0de.
 %%     </p>
 %%   </dd>
 %%   <dt>`{timeout, non_neg_integer()}'</dt>

--- a/src/eipmi.erl
+++ b/src/eipmi.erl
@@ -1425,7 +1425,7 @@ do_ping(IPAddress, Timeout, Socket) ->
 %%------------------------------------------------------------------------------
 do_ping_receive(IPAddress, Timeout, Socket) ->
     {ok, {_, _, Packet}} = gen_udp:recv(Socket, 8192, Timeout),
-    case eipmi_decoder:packet(Packet) of
+    case eipmi_decoder:packet(Packet, []) of
         {ok, #rmcp_ack{}} ->
             do_ping_receive(IPAddress, Timeout, Socket);
         {ok, #rmcp_asf{header = H, payload = #asf_pong{entities = Es}}} ->

--- a/src/eipmi.erl
+++ b/src/eipmi.erl
@@ -753,7 +753,7 @@ set_chassis_capabilities(Session, FruAddr, SdrAddr, SelAddr, SmAddr, Extra) ->
 %% @doc
 %% Returns the capabilities reported by the Chassis device as a proplist. In
 %% addition to those modifiable by {@link set_chassis_capabilities/6}, also
-%% reports whether it has apower interlock (`interlock`) and diagnostic
+%% reports whether it has a power interlock (`interlock`) and diagnostic
 %% interrupt (`diagnostic`).
 %% @end
 %%------------------------------------------------------------------------------

--- a/src/eipmi_auth.erl
+++ b/src/eipmi_auth.erl
@@ -72,10 +72,11 @@ hash(md5, Binary) ->
 hash(pwd, Password) ->
     eipmi_util:normalize(16, Password).
 
--spec hash(integrity_type(), binary(), binary()) -> binary().
+-spec hash(integrity_type(), iodata(), binary()) -> binary().
 hash(none, _Key, _Ignored) ->
     <<>>;
-hash(md5_128, Key, Binary) ->
+hash(md5_128, K, Binary) ->
+    Key = iolist_to_binary(K),
     crypto:hash(md5, <<Key/binary, Binary/binary, Key/binary>>);
 hash(hmac_sha1_96, K, B) ->
     crypto:macN(hmac, sha, K, B, 12);

--- a/src/eipmi_auth.erl
+++ b/src/eipmi_auth.erl
@@ -21,11 +21,15 @@
 
 -module(eipmi_auth).
 
--export([encrypt/2,
+-export([encrypt/3,
+         decrypt/3,
          encode_type/1,
-         decode_type/1]).
+         decode_type/1,
+         hash/2
+        ]).
 
--type type() :: none | md2 | md5 | pwd.
+-type encrypt_type() :: none | aes_cbc.
+-type type() :: none | md2 | md5 | pwd | rmcp_plus.
 
 -export_type([type/0]).
 
@@ -35,40 +39,73 @@
 
 %%------------------------------------------------------------------------------
 %% @doc
-%% Encrypts a given binary according to the requested authentication
+%% Hashes a given binary according to the requested authentication
 %% algorithm. The returned cipher is always a binary of 16bytes or an empty
 %% binary for authentication code `none'. Straight passwords are either padded
 %% or cut to a length of 16bytes.
 %% @end
 %%------------------------------------------------------------------------------
--spec encrypt(type(), binary() | string()) -> binary().
-encrypt(none, _Ignored) ->
+-spec hash(type(), binary() | string()) -> binary().
+hash(none, _Ignored) ->
     <<>>;
-encrypt(md2, Binary) ->
+hash(md2, Binary) ->
     md2:hash(Binary);
-encrypt(md5, Binary) ->
+hash(md5, Binary) ->
     crypto:hash(md5, Binary);
-encrypt(pwd, Password) ->
+hash(pwd, Password) ->
     eipmi_util:normalize(16, Password).
+
+%%-------------------------------------------------------------------------------
+%% @doc
+%% Encrypts a given binary according to the requested confidentiality
+%% algorithm. Returns a binary containing the Confidentiality Header and the
+%% encrypted Payload + Confidentiality Trailer.
+%%-------------------------------------------------------------------------------
+-spec encrypt(encrypt_type(), binary(), binary()) -> binary().
+encrypt(none, _Key, Binary) ->
+    Binary;
+encrypt(aes_cbc, Key, Binary) ->
+    Iv = crypto:strong_rand_bytes(16),
+    % IPMI uses a different padding scheme than the
+    % crypto library: pad to a multiple of 16 bytes,
+    % less 1 to encode the padding length; the padding
+    % bytes are sequential numbers starting from 1.
+    PadLength = 15 - size(Binary) rem 16,
+    Padding = list_to_binary(lists:seq(1, PadLength)),
+    ToEncrypt = <<Binary/binary, Padding/binary, PadLength:8>>,
+    Encrypted = crypto:crypto_one_time(aes_128_cbc, Key, Iv, ToEncrypt,
+                                       [{encrypt, true}, {padding, none}]),
+    <<Iv/binary, Encrypted/binary>>.
+
+decrypt(none, _Key, Binary) ->
+    Binary;
+decrypt(aes_cbc, Key, <<Iv:16/binary, Encrypted/binary>>) ->
+    Result = crypto:crypto_one_time(aes_128_cbc, Key, Iv, Encrypted,
+                                    [{encrypt, false}, {padding, none}]),
+    PadLength = binary:last(Result),
+    % PadLength does not count its own byte.
+    binary_part(Result, {0, size(Result) - 1 - PadLength}).
 
 %%------------------------------------------------------------------------------
 %% @doc
 %% Encodes an authentication type into its integer representation.
 %% @end
 %%------------------------------------------------------------------------------
--spec encode_type(type()) -> 0..4.
+-spec encode_type(type()) -> 0..6.
 encode_type(none) -> 0;
 encode_type(md2) -> 1;
 encode_type(md5) -> 2;
-encode_type(pwd) -> 4.
+encode_type(pwd) -> 4;
+encode_type(rmcp_plus) -> 6.
 
 %%------------------------------------------------------------------------------
 %% @doc
 %% Decodes an authentication type integer into human readable format.
 %% @end
 %%------------------------------------------------------------------------------
--spec decode_type(0..4) -> type().
+-spec decode_type(0..6) -> type().
 decode_type(0) -> none;
 decode_type(1) -> md2;
 decode_type(2) -> md5;
-decode_type(4) -> pwd.
+decode_type(4) -> pwd;
+decode_type(6) -> rmcp_plus.

--- a/src/eipmi_decoder.erl
+++ b/src/eipmi_decoder.erl
@@ -122,7 +122,7 @@ authenticate(Ps, Binary) ->
                     3 -> 3
                 end,
     <<Padding:PadLength/binary, PadLength:8, 16#07:8, AuthCode/binary>> = SessionTrailer,
-    H = proplists:get_value(hash_type, Ps),
+    H = proplists:get_value(integrity_type, Ps),
     SIK = proplists:get_value(session_key, Ps),
     K1 = eipmi_auth:extra_key(1, H, SIK),
     Hashed = <<SessionHeader/binary, Size:16/little, Data/binary,
@@ -137,7 +137,7 @@ maybe_encrypted(#rmcp_ipmi{properties = Ps} = I, Len, Data) ->
     case proplists:get_value(encrypted, Ps) of
         true ->
             E = proplists:get_value(encrypt_type, Ps, none),
-            H = proplists:get_value(hash_type, Ps),
+            H = proplists:get_value(integrity_type, Ps),
             SIK = proplists:get_value(session_key, Ps),
             K2 = eipmi_auth:extra_key(E, H, SIK),
             Resp = eipmi_auth:decrypt(E, K2, Data),

--- a/src/eipmi_encoder.erl
+++ b/src/eipmi_encoder.erl
@@ -94,11 +94,11 @@ ipmi(Header = #rmcp_header{class = ?RMCP_IPMI}, Properties, Req, Data) ->
             AuthCode = eipmi_auth:hash(H, K1, Hashed),
             <<HeaderBin/binary, SessionBin/binary, Hashed/binary, AuthCode/binary>>;
         AuthType ->
+            RequestBin = request(Properties, Req, Data),
             S = proplists:get_value(inbound_seq_nr, Properties),
             I = proplists:get_value(session_id, Properties),
             P = proplists:get_value(password, Properties),
-            SessionBin = session1(AuthType, S, I, P, Data),
-            RequestBin = request(Properties, Req, Data),
+            SessionBin = session1(AuthType, S, I, P, RequestBin),
             Length = size(RequestBin),
             <<HeaderBin/binary, SessionBin/binary, Length:8, RequestBin/binary>>
     end.

--- a/src/eipmi_request.erl
+++ b/src/eipmi_request.erl
@@ -101,7 +101,7 @@ encode_application(?GET_CHANNEL_AUTHENTICATION_CAPABILITIES, Properties) ->
     P = encode_privilege(proplists:get_value(privilege, Properties)),
     <<0:1, 0:3, ?IPMI_REQUESTED_CHANNEL:4, 0:4,P:4>>;
 encode_application(?GET_SESSION_CHALLENGE, Properties) ->
-    A = eipmi_auth:encode_type(proplists:get_value(auth_type, Properties)),
+    A = eipmi_auth:encode_type(proplists:get_value(rq_auth_type, Properties)),
     U = eipmi_util:normalize(16, proplists:get_value(user, Properties)),
     <<0:4, A:4, U/binary>>;
 encode_application(?ACTIVATE_SESSION, Properties) ->

--- a/src/eipmi_request.erl
+++ b/src/eipmi_request.erl
@@ -99,7 +99,7 @@ encode_application(?SEND_MESSAGE, Properties) ->
     <<1:2, 0:2, Channel:4, Request/binary>>;
 encode_application(?GET_CHANNEL_AUTHENTICATION_CAPABILITIES, Properties) ->
     P = encode_privilege(proplists:get_value(privilege, Properties)),
-    <<0:1, 0:3, ?IPMI_REQUESTED_CHANNEL:4, 0:4,P:4>>;
+    <<1:1, 0:3, ?IPMI_REQUESTED_CHANNEL:4, 0:4,P:4>>;
 encode_application(?GET_SESSION_CHALLENGE, Properties) ->
     A = eipmi_auth:encode_type(proplists:get_value(rq_auth_type, Properties)),
     U = eipmi_util:normalize(16, proplists:get_value(user, Properties)),

--- a/src/eipmi_response.erl
+++ b/src/eipmi_response.erl
@@ -527,32 +527,26 @@ decode_oem(_, _, Data) -> [{data, Data}].
 %%------------------------------------------------------------------------------
 %% @private
 %%------------------------------------------------------------------------------
-decode_open_session_rs(<<Status:8, ?EIPMI_RESERVED:8, Sq:32/little>>) ->
-    {error, [{status_code, Status},
-             {rq_session_id, Sq}]};
-decode_open_session_rs(<<Tag:8, Status:8, ?EIPMI_RESERVED:4, P:4, ?EIPMI_RESERVED:8, Sq:32/little, Ss:32/little,
+decode_open_session_rs(<<?EIPMI_RESERVED:8, Sq:32/little>>) ->
+    {error, [{rq_session_id, Sq}]};
+decode_open_session_rs(<<?EIPMI_RESERVED:4, P:4, ?EIPMI_RESERVED:8, Sq:32/little, Ss:32/little,
                          0:8, ?EIPMI_RESERVED:16, 8:8, ?EIPMI_RESERVED:2, A:6, ?EIPMI_RESERVED:24,
                          1:8, ?EIPMI_RESERVED:16, 8:8, ?EIPMI_RESERVED:2, I:6, ?EIPMI_RESERVED:24,
                          2:8, ?EIPMI_RESERVED:16, 8:8, ?EIPMI_RESERVED:2, E:6, ?EIPMI_RESERVED:24>>) ->
-    {ok, [{message_tag, Tag},
-     {status_code, Status},
-     {privilege, decode_privilege(P)},
-     {rq_session_id, Sq},
-     {rs_session_id, Ss},
-     {rakp_auth_type, eipmi_auth:decode_rakp_type(A)},
-     {integrity_type, eipmi_auth:decode_integrity_type(I)},
-     {encrypt_type, eipmi_auth:decode_encrypt_type(E)}]}.
+    {ok, [{privilege, decode_privilege(P)},
+          {rq_session_id, Sq},
+          {rs_session_id, Ss},
+          {rakp_auth_type, eipmi_auth:decode_rakp_type(A)},
+          {integrity_type, eipmi_auth:decode_integrity_type(I)},
+          {encrypt_type, eipmi_auth:decode_encrypt_type(E)}]}.
 
 %%------------------------------------------------------------------------------
 %% @private
 %%------------------------------------------------------------------------------
-decode_rakp2(<<Status:8, ?EIPMI_RESERVED:32, Sq:32/little>>) ->
-    {error, [{status_code, Status},
-             {rq_session_id, Sq}]};
-decode_rakp2(<<Tag:8, Status:8, ?EIPMI_RESERVED:32, Sq:32/little, Rs:128/little, Guid:128/little, Auth/binary>>) ->
-    {ok, [{message_tag, Tag},
-          {status_code, Status},
-          {rq_session_id, Sq},
+decode_rakp2(<<?EIPMI_RESERVED:16, Sq:32/little>>) ->
+    {error, [{rq_session_id, Sq}]};
+decode_rakp2(<<?EIPMI_RESERVED:16, Sq:32/little, Rs:16/binary, Guid:128/little, Auth/binary>>) ->
+    {ok, [{rq_session_id, Sq},
           {rs_nonce, Rs},
           {system_guid, Guid},
           {auth_code, Auth}]}.
@@ -560,13 +554,10 @@ decode_rakp2(<<Tag:8, Status:8, ?EIPMI_RESERVED:32, Sq:32/little, Rs:128/little,
 %%------------------------------------------------------------------------------
 %% @private
 %%------------------------------------------------------------------------------
-decode_rakp4(<<Status:8, ?EIPMI_RESERVED:16, Ss:32/little>>) ->
-    {error, [{status_code, Status},
-             {rs_session_id, Ss}]};
-decode_rakp4(<<Tag:8, Status:8, ?EIPMI_RESERVED:16, Ss:32/little, Integrity/binary>>) ->
-    {ok, [{message_tag, Tag},
-          {status_code, Status},
-          {rs_session_id, Ss},
+decode_rakp4(<<?EIPMI_RESERVED:16, Ss:32/little>>) ->
+    {error, [{rs_session_id, Ss}]};
+decode_rakp4(<<?EIPMI_RESERVED:16, Ss:32/little, Integrity/binary>>) ->
+    {ok, [{rs_session_id, Ss},
           {integrity_value, Integrity}]}.
 
 %%------------------------------------------------------------------------------

--- a/src/eipmi_response.erl
+++ b/src/eipmi_response.erl
@@ -39,13 +39,19 @@
 %% property list with the decoded values.
 %% @end
 %%------------------------------------------------------------------------------
--spec decode(eipmi:response(), binary()) ->
+-spec decode(eipmi:response() | open_session_rs | rakp2 | rakp4, binary()) ->
                     {ok, proplists:proplist()} | {error, term()}.
 decode({NetFn, Cmd}, Data) ->
     try decode(NetFn, Cmd, Data)
     catch
         C:E -> {error, {C, E}}
-    end.
+    end;
+decode(open_session_rs, Data) ->
+    decode_open_session_rs(Data);
+decode(rakp2, Data) ->
+    decode_rakp2(Data);
+decode(rakp4, Data) ->
+    decode_rakp4(Data).
 decode(?IPMI_NETFN_SENSOR_EVENT_RESPONSE, Cmd, Data) ->
     {ok, decode_sensor_event(Cmd, Data)};
 decode(?IPMI_NETFN_APPLICATION_RESPONSE, Cmd, Data) ->
@@ -517,6 +523,51 @@ decode_picmg_(?GET_DEVICE_LOCATOR_RECORD_ID, [Id]) ->
 %% @private
 %%------------------------------------------------------------------------------
 decode_oem(_, _, Data) -> [{data, Data}].
+
+%%------------------------------------------------------------------------------
+%% @private
+%%------------------------------------------------------------------------------
+decode_open_session_rs(<<Status:8, ?EIPMI_RESERVED:8, Sq:32/little>>) ->
+    {error, [{status_code, Status},
+             {rq_session_id, Sq}]};
+decode_open_session_rs(<<Tag:8, Status:8, ?EIPMI_RESERVED:4, P:4, ?EIPMI_RESERVED:8, Sq:32/little, Ss:32/little,
+                         0:8, ?EIPMI_RESERVED:16, 8:8, ?EIPMI_RESERVED:2, A:6, ?EIPMI_RESERVED:24,
+                         1:8, ?EIPMI_RESERVED:16, 8:8, ?EIPMI_RESERVED:2, I:6, ?EIPMI_RESERVED:24,
+                         2:8, ?EIPMI_RESERVED:16, 8:8, ?EIPMI_RESERVED:2, E:6, ?EIPMI_RESERVED:24>>) ->
+    {ok, [{message_tag, Tag},
+     {status_code, Status},
+     {privilege, decode_privilege(P)},
+     {rq_session_id, Sq},
+     {rs_session_id, Ss},
+     {rakp_auth_type, eipmi_auth:decode_rakp_type(A)},
+     {integrity_type, eipmi_auth:decode_integrity_type(I)},
+     {encrypt_type, eipmi_auth:decode_encrypt_type(E)}]}.
+
+%%------------------------------------------------------------------------------
+%% @private
+%%------------------------------------------------------------------------------
+decode_rakp2(<<Status:8, ?EIPMI_RESERVED:32, Sq:32/little>>) ->
+    {error, [{status_code, Status},
+             {rq_session_id, Sq}]};
+decode_rakp2(<<Tag:8, Status:8, ?EIPMI_RESERVED:32, Sq:32/little, Rs:128/little, Guid:128/little, Auth/binary>>) ->
+    {ok, [{message_tag, Tag},
+          {status_code, Status},
+          {rq_session_id, Sq},
+          {rs_nonce, Rs},
+          {system_guid, Guid},
+          {auth_code, Auth}]}.
+
+%%------------------------------------------------------------------------------
+%% @private
+%%------------------------------------------------------------------------------
+decode_rakp4(<<Status:8, ?EIPMI_RESERVED:16, Ss:32/little>>) ->
+    {error, [{status_code, Status},
+             {rs_session_id, Ss}]};
+decode_rakp4(<<Tag:8, Status:8, ?EIPMI_RESERVED:16, Ss:32/little, Integrity/binary>>) ->
+    {ok, [{message_tag, Tag},
+          {status_code, Status},
+          {rs_session_id, Ss},
+          {integrity_value, Integrity}]}.
 
 %%------------------------------------------------------------------------------
 %% @private

--- a/src/eipmi_session.erl
+++ b/src/eipmi_session.erl
@@ -72,13 +72,22 @@
 
 -type property() ::
         eipmi:option() |
-        {auth_type, none | pwd | md5 | md2} |
-        {auth_types, [none | pwd | md5 | md2]} |
+        {auth_type, eipmi_auth:type()} |
+        {auth_types, [eipmi_auth:type()]} |
         {challenge, binary()} |
         {completion, atom()} |
+        {encrypt_type, eipmi_auth:encrypt_type()} |
+        {encrypt_types, [eipmi_auth:encrypt_type()]} |
         {inbound_seq_nr, non_neg_integer()} |
+        {inbound_unauth_seq_nr, non_neg_integer()} |
+        {inbound_auth_seq_nr, non_neg_integer()} |
+        {integrity_type, eipmi_auth:integrity_type()} |
+        {integrity_types, [eipmi_auth:integrity_type()]} |
         {login_status, [anonymous | null | non_null]} |
         {outbound_seq_nr, non_neg_integer()} |
+        {outbound_unauth_seq_nr, non_neg_integer()} |
+        {outbound_auth_seq_nr, non_neg_integer()} |
+        {payload_type, eipmi_auth:payload_type()} |
         {rq_auth_type, none | pwd | md5 | md2} |
         {rq_seq_nr, 0..16#40} |
         {session_id, non_neg_integer()}.
@@ -89,9 +98,16 @@
         auth_types |
         challenge |
         completion |
+        encrypt_type |
+        encrypt_types |
         inbound_seq_nr |
+        inbound_unauth_seq_nr |
+        inbound_auth_seq_nr |
         login_status |
         outbound_seq_nr |
+        outbound_unauth_seq_nr |
+        outbound_auth_seq_nr |
+        payload_type |
         rq_auth_type |
         rq_seq_nr |
         session_id.
@@ -112,17 +128,24 @@
          {port, ?RMCP_PORT_NUMBER},
          {privilege, administrator},
          {rq_addr, ?IPMI_REQUESTOR_ADDR},
+         {rq_auth_type, md5},
          {timeout, 1000},
          {user, ""},
          %% unmodifyable session defaults
-         {auth_type, none},    %% initial packets are not authenticated
-         {inbound_seq_nr, 0},  %% initial packets have the null seqnr
-         {outbound_seq_nr, 0}, %% initial packets have the null seqnr
+         {auth_type, none},      %% initial packets are not authenticated
+         {encrypt_type, none},   %% initial packets are not encrypted
+         {integrity_type, none}, %% AuthCode type when `auth_type` is `rmcp_plus`
+         {inbound_seq_nr, 0},    %% initial packets have the null seqnr
+         {inbound_unauth_seq_nr, 0},
+         {inbound_auth_seq_nr, 0},
+         {outbound_seq_nr, 0},   %% initial packets have the null seqnr
+         {outbound_unauth_seq_nr, 0},
+         {outbound_auth_seq_nr, 0},
          {rq_lun, ?IPMI_REQUESTOR_LUN},
-         {rq_seq_nr, 0},       %% initial requests have the null seqnr
+         {rq_seq_nr, 0},         %% initial requests have the null seqnr
          {rs_addr, ?IPMI_RESPONDER_ADDR},
          {rs_lun, ?IPMI_RESPONDER_LUN},
-         {session_id, 0}       %% initial have the null session id
+         {session_id, 0}         %% initial have the null session id
         ]).
 
 %%%=============================================================================

--- a/test/eipmi_auth_tests.erl
+++ b/test/eipmi_auth_tests.erl
@@ -26,48 +26,62 @@ none_test() ->
     AuthType = none,
     Unencrypted = <<"abcd">>,
     Encrypted = <<>>,
-    ?assertEqual(Encrypted, eipmi_auth:encrypt(AuthType, Unencrypted)),
+    ?assertEqual(Encrypted, eipmi_auth:hash(AuthType, Unencrypted)),
     ?assert(validate(AuthType, Unencrypted, Encrypted)).
 
 md2_test() ->
     AuthType = md2,
     Unencrypted = <<"abcd">>,
-    Encrypted = eipmi_auth:encrypt(AuthType, Unencrypted),
+    Encrypted = eipmi_auth:hash(AuthType, Unencrypted),
     ?assert(validate(AuthType, Unencrypted, Encrypted)).
 
 md5_test() ->
     AuthType = md5,
     Unencrypted = <<"abcd">>,
-    Encrypted = eipmi_auth:encrypt(AuthType, Unencrypted),
+    Encrypted = eipmi_auth:hash(AuthType, Unencrypted),
     ?assert(validate(AuthType, Unencrypted, Encrypted)).
 
 string_pwd_test() ->
     AuthType = pwd,
     Unencrypted = "abcd",
     Encrypted = <<"abcd", 0:(12*8)>>,
-    ?assertEqual(Encrypted, eipmi_auth:encrypt(AuthType, Unencrypted)),
+    ?assertEqual(Encrypted, eipmi_auth:hash(AuthType, Unencrypted)),
     ?assert(validate(AuthType, Unencrypted, Encrypted)).
 
 short_pwd_test() ->
     AuthType = pwd,
     Unencrypted = <<"abcd">>,
     Encrypted = <<"abcd", 0:(12*8)>>,
-    ?assertEqual(Encrypted, eipmi_auth:encrypt(AuthType, Unencrypted)),
+    ?assertEqual(Encrypted, eipmi_auth:hash(AuthType, Unencrypted)),
     ?assert(validate(AuthType, Unencrypted, Encrypted)).
 
 exact_pwd_test() ->
     AuthType = pwd,
     Unencrypted = <<"abcdefghijklmnop">>,
     Encrypted = <<"abcdefghijklmnop">>,
-    ?assertEqual(Encrypted, eipmi_auth:encrypt(AuthType, Unencrypted)),
+    ?assertEqual(Encrypted, eipmi_auth:hash(AuthType, Unencrypted)),
     ?assert(validate(AuthType, Unencrypted, Encrypted)).
 
 long_pwd_test() ->
     AuthType = pwd,
     Unencrypted = <<"abcdefghijklmnopqrstuvwxyz">>,
     Encrypted = <<"abcdefghijklmnop">>,
-    ?assertEqual(Encrypted, eipmi_auth:encrypt(AuthType, Unencrypted)),
+    ?assertEqual(Encrypted, eipmi_auth:hash(AuthType, Unencrypted)),
     ?assert(validate(AuthType, Unencrypted, Encrypted)).
+
+none_encryption_test() ->
+    EncryptType = none,
+    Key = <<>>,
+    Unencrypted = <<"abc">>,
+    ?assertEqual(Unencrypted, eipmi_auth:encrypt(EncryptType, Key, Unencrypted)),
+    ?assertEqual(Unencrypted, eipmi_auth:decrypt(EncryptType, Key, Unencrypted)).
+
+aes_encryption_test() ->
+    EncryptType = aes_cbc,
+    Key = crypto:strong_rand_bytes(16),
+    Unencrypted = <<"abcdefghijklmnopqrstuvwxyz">>,
+    Encrypted = eipmi_auth:encrypt(EncryptType, Key, Unencrypted),
+    ?assertEqual(Unencrypted, eipmi_auth:decrypt(EncryptType, Key, Encrypted)).
 
 %%%=============================================================================
 %%% internal functions
@@ -76,4 +90,4 @@ long_pwd_test() ->
 validate(none, _, _) ->
     true;
 validate(AuthType, Unencrypted, Encrypted) ->
-    eipmi_auth:encrypt(AuthType, Unencrypted) =:= Encrypted.
+    eipmi_auth:hash(AuthType, Unencrypted) =:= Encrypted.

--- a/test/eipmi_auth_tests.erl
+++ b/test/eipmi_auth_tests.erl
@@ -70,7 +70,7 @@ long_pwd_test() ->
     ?assert(validate(AuthType, Unencrypted, Encrypted)).
 
 hmac_md5_test() ->
-    HashType = hmac_md5,
+    HashType = hmac_md5_128,
     Key =
         <<16#37, 16#8d, 16#60, 16#63, 16#fe, 16#16,
           16#05, 16#2c, 16#cc, 16#40, 16#bf, 16#88,
@@ -83,7 +83,7 @@ hmac_md5_test() ->
     ?assertEqual(Hashed, eipmi_auth:hash(HashType, Key, Clear)).
 
 hmac_sha1_test() ->
-    HashType = hmac_sha1,
+    HashType = hmac_sha1_96,
     Key =
         <<16#37, 16#8d, 16#60, 16#63, 16#fe, 16#16,
           16#05, 16#2c, 16#cc, 16#40, 16#bf, 16#88,
@@ -91,13 +91,11 @@ hmac_sha1_test() ->
     Clear = <<"abcdefghijklmnopqrstuvwxyz">>,
     Hashed =
         <<16#82, 16#5b, 16#5b, 16#c1, 16#7b, 16#56,
-          16#f9, 16#d9, 16#27, 16#72, 16#76, 16#07,
-          16#3c, 16#c6, 16#64, 16#d4, 16#71, 16#d6,
-          16#78, 16#74>>,
+          16#f9, 16#d9, 16#27, 16#72, 16#76, 16#07>>,
     ?assertEqual(Hashed, eipmi_auth:hash(HashType, Key, Clear)).
 
 hmac_sha256_test() ->
-    HashType = hmac_sha256,
+    HashType = hmac_sha256_128,
     Key =
         <<16#37, 16#8d, 16#60, 16#63, 16#fe, 16#16,
           16#05, 16#2c, 16#cc, 16#40, 16#bf, 16#88,
@@ -106,10 +104,7 @@ hmac_sha256_test() ->
     Hashed =
         <<16#33, 16#ca, 16#58, 16#57, 16#8a, 16#fc,
           16#86, 16#e6, 16#6d, 16#24, 16#8d, 16#98,
-          16#0f, 16#6d, 16#8d, 16#06, 16#1c, 16#af,
-          16#b0, 16#dd, 16#5f, 16#e7, 16#3e, 16#a6,
-          16#ec, 16#cd, 16#72, 16#09, 16#d1, 16#d7,
-          16#3b, 16#24>>,
+          16#0f, 16#6d, 16#8d, 16#06>>,
     ?assertEqual(Hashed, eipmi_auth:hash(HashType, Key, Clear)).
 
 none_encryption_test() ->

--- a/test/eipmi_auth_tests.erl
+++ b/test/eipmi_auth_tests.erl
@@ -69,6 +69,49 @@ long_pwd_test() ->
     ?assertEqual(Encrypted, eipmi_auth:hash(AuthType, Unencrypted)),
     ?assert(validate(AuthType, Unencrypted, Encrypted)).
 
+hmac_md5_test() ->
+    HashType = hmac_md5,
+    Key =
+        <<16#37, 16#8d, 16#60, 16#63, 16#fe, 16#16,
+          16#05, 16#2c, 16#cc, 16#40, 16#bf, 16#88,
+          16#92, 16#af, 16#28, 16#4a>>,
+    Clear = <<"abcdefghijklmnopqrstuvwxyz">>,
+    Hashed =
+        <<16#04, 16#c0, 16#46, 16#ef, 16#75, 16#a1,
+          16#ff, 16#11, 16#db, 16#4d, 16#f3, 16#b2,
+          16#39, 16#21, 16#20, 16#59>>,
+    ?assertEqual(Hashed, eipmi_auth:hash(HashType, Key, Clear)).
+
+hmac_sha1_test() ->
+    HashType = hmac_sha1,
+    Key =
+        <<16#37, 16#8d, 16#60, 16#63, 16#fe, 16#16,
+          16#05, 16#2c, 16#cc, 16#40, 16#bf, 16#88,
+          16#92, 16#af, 16#28, 16#4a>>,
+    Clear = <<"abcdefghijklmnopqrstuvwxyz">>,
+    Hashed =
+        <<16#82, 16#5b, 16#5b, 16#c1, 16#7b, 16#56,
+          16#f9, 16#d9, 16#27, 16#72, 16#76, 16#07,
+          16#3c, 16#c6, 16#64, 16#d4, 16#71, 16#d6,
+          16#78, 16#74>>,
+    ?assertEqual(Hashed, eipmi_auth:hash(HashType, Key, Clear)).
+
+hmac_sha256_test() ->
+    HashType = hmac_sha256,
+    Key =
+        <<16#37, 16#8d, 16#60, 16#63, 16#fe, 16#16,
+          16#05, 16#2c, 16#cc, 16#40, 16#bf, 16#88,
+          16#92, 16#af, 16#28, 16#4a>>,
+    Clear = <<"abcdefghijklmnopqrstuvwxyz">>,
+    Hashed =
+        <<16#33, 16#ca, 16#58, 16#57, 16#8a, 16#fc,
+          16#86, 16#e6, 16#6d, 16#24, 16#8d, 16#98,
+          16#0f, 16#6d, 16#8d, 16#06, 16#1c, 16#af,
+          16#b0, 16#dd, 16#5f, 16#e7, 16#3e, 16#a6,
+          16#ec, 16#cd, 16#72, 16#09, 16#d1, 16#d7,
+          16#3b, 16#24>>,
+    ?assertEqual(Hashed, eipmi_auth:hash(HashType, Key, Clear)).
+
 none_encryption_test() ->
     EncryptType = none,
     Key = <<>>,

--- a/test/eipmi_decoder_tests.erl
+++ b/test/eipmi_decoder_tests.erl
@@ -27,22 +27,22 @@
 not_rmcp_packet_test() ->
     ?assertEqual(
        {error, {not_rmcp_packet, <<>>}},
-       eipmi_decoder:packet(<<>>)).
+       eipmi_decoder:packet(<<>>, [])).
 
 unsupported_rmcp_packet_test() ->
     ?assertEqual(
        {error, unsupported_rmcp_packet},
-       eipmi_decoder:packet(<<16#06, 16#00, 16#01, 16#00>>)).
+       eipmi_decoder:packet(<<16#06, 16#00, 16#01, 16#00>>, [])).
 
 unsupported_asf_packet_test() ->
     ?assertEqual(
        {error, unsupported_asf_packet},
-       eipmi_decoder:packet(<<16#06, 16#00, 16#01, 16#06, 16#00, 16#00>>)).
+       eipmi_decoder:packet(<<16#06, 16#00, 16#01, 16#06, 16#00, 16#00>>, [])).
 
 ack_test() ->
     ?assertEqual(
        {ok, #rmcp_ack{header = #rmcp_header{seq_nr = 1}}},
-       eipmi_decoder:packet(<<16#06, 16#00, 16#01, 16#86>>)).
+       eipmi_decoder:packet(<<16#06, 16#00, 16#01, 16#86>>, [])).
 
 pong_test() ->
     ?assertEqual(
@@ -53,7 +53,7 @@ pong_test() ->
          <<16#06, 16#00, 16#01, 16#06, 16#00, 16#00, 16#11,
            16#be, 16#40, 16#00, 16#00, 16#10, 16#00, 16#00,
            16#11, 16#be, 16#00, 16#00, 16#00, 16#00, 16#81,
-           16#00, 16#00, 16#00, 16#00, 16#00, 16#00, 16#00>>)).
+           16#00, 16#00, 16#00, 16#00, 16#00, 16#00, 16#00>>, [])).
 
 ipmi_response_test() ->
     {ok, Ipmi} =
@@ -62,7 +62,7 @@ ipmi_response_test() ->
             16#00, 16#00, 16#00, 16#00, 16#00, 16#00, 16#10,
             16#81, 16#1c, 16#63, 16#20, 16#00, 16#38, 16#00,
             16#00, 16#01, 16#19, 16#00, 16#00, 16#00, 16#00,
-            16#00, 16#8e>>),
+            16#00, 16#8e>>, []),
     ?assertMatch(
        #rmcp_ipmi{
           header = #rmcp_header{class = ?RMCP_IPMI},

--- a/test/eipmi_request_tests.erl
+++ b/test/eipmi_request_tests.erl
@@ -90,7 +90,7 @@ encode_send_message_test() ->
 encode_get_channel_authentication_capabilities_test() ->
     Req = {?IPMI_NETFN_APPLICATION_REQUEST, ?GET_CHANNEL_AUTHENTICATION_CAPABILITIES},
     Properties = [{privilege, administrator}],
-    ?assertEqual(<<16#0e, 16#04>>, eipmi_request:encode(Req, Properties)).
+    ?assertEqual(<<16#8e, 16#04>>, eipmi_request:encode(Req, Properties)).
 
 encode_get_session_challenge_test() ->
     Req = {?IPMI_NETFN_APPLICATION_REQUEST, ?GET_SESSION_CHALLENGE},

--- a/test/eipmi_request_tests.erl
+++ b/test/eipmi_request_tests.erl
@@ -94,7 +94,7 @@ encode_get_channel_authentication_capabilities_test() ->
 
 encode_get_session_challenge_test() ->
     Req = {?IPMI_NETFN_APPLICATION_REQUEST, ?GET_SESSION_CHALLENGE},
-    Properties = [{auth_type, none}, {user, "hello_world"}],
+    Properties = [{rq_auth_type, none}, {user, "hello_world"}],
     ?assertEqual(
        <<16#00, $h, $e, $l, $l, $o, $_, $w, $o, $r, $l, $d,
          16#00, 16#00, 16#00, 16#00, 16#00>>,


### PR DESCRIPTION
This is an initial attempt at supporting IPMI v2.0 and RMCP+. I've taken a bottom-up approach by adding and changing the functions in eipmi_auth, eipmi_encoder, and eipmi_decoder first. Still to be done are the high-level functions for eipmi and eipmi_session to handle the more complicated session routine, but I think I've done a large enough chunk to get feedback.

I have discovered that there needs to be some way to access the session state's properties from the decoder in order to decrypt and authenticate the IPMI messages. I was concerned about having to make API changes, but this would actually bring it closer to the way the encoder works, and I've already changed eipmi_auth's API anyway.