### PR TITLE
Make empty SDR repository "older" than current info.

### DIFF
--- a/src/eipmi_sdr.erl
+++ b/src/eipmi_sdr.erl
@@ -889,8 +889,8 @@ get_offsets(<<1:1, R/bitstring>>, I, Acc) -> get_offsets(R, I - 1, [I | Acc]).
 %%------------------------------------------------------------------------------
 get_recent_action_timestamp(SdrInfo) ->
     erlang:max(
-      to_timestamp(proplists:get_value(most_recent_addition, SdrInfo, 0)),
-      to_timestamp(proplists:get_value(most_recent_erase, SdrInfo, 0))).
+      to_timestamp(proplists:get_value(most_recent_addition, SdrInfo, -1)),
+      to_timestamp(proplists:get_value(most_recent_erase, SdrInfo, -1))).
 
 %%------------------------------------------------------------------------------
 %% @private


### PR DESCRIPTION
This lets us get the whole repository when we know nothing about the system, as happens on startup.