### PR TITLE
Cover sensor edge case

### DIFF
--- a/src/eipmi_sdr.erl
+++ b/src/eipmi_sdr.erl
@@ -936,6 +936,8 @@ get_reading(Tag, Raw, Properties) ->
 %%------------------------------------------------------------------------------
 get_reading(_, U, _, _, _) when U =:= unspecified orelse U =:= undefined ->
     [];
+get_reading(Tag, Unit, _, undefined, _) ->
+    [{Tag, {undefined, Unit}}];
 get_reading(Tag, Unit, unsigned, <<Value:8/unsigned>>, Coefficients) ->
     [{Tag, calc_reading(Unit, Value, Coefficients)}];
 get_reading(Tag, Unit, ones_complement, <<1:1, Raw:7>>, Coefficients) ->


### PR DESCRIPTION
Sometimes sensors return no data. I believe this happens when the host is off, but the BMC can be commanded to turn it on. I was looking for the "SYSTEM_POWER" sensor, which returned no reading at all in this situation, but caused a FunctionClauseError.